### PR TITLE
fix hardlinks to numpy v1.17.0 assets

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -61,11 +61,7 @@ Welcome! This is the documentation for Numpy and Scipy.
          Numpy (development version) User Guide</a>
       </p>
       <p><a href="numpy-1.17.0/reference/">Numpy 1.17.0 Reference Guide</a>,
-        <span><a href="numpy-1.17.0/numpy-html-1.17.0
-        
-        
-        
-        ">[HTML+zip]</a>,
+        <span><a href="numpy-1.17.0/numpy-html-1.17.0.zip">[HTML+zip]</a>,
           <a href="numpy-1.17.0/numpy-ref-1.17.0.pdf">[PDF]</a></span>
       </p>
       <p><a href="numpy-1.17.0/user/">Numpy 1.17.0 User Guide</a>,

--- a/index.rst
+++ b/index.rst
@@ -34,7 +34,7 @@ Welcome! This is the documentation for Numpy and Scipy.
         <span><a href="numpy/numpy-ref-1.17.0.pdf">[PDF]</a></span>
       </p>
       <p class="biglink"><a class="biglink" href="numpy/user/">Numpy User Guide</a><br/>
-        <span><a href="numpy/numpy-user-1.17.0.pdf">[PDF]</a></span>
+        <span><a href="https://numpy.org/doc/1.21/numpy-ref.pdf">[PDF]</a></span>
       </p>
       <p class="biglink"><a class="biglink" href="numpy/f2py/">F2Py Guide</a><br/>
       </p>

--- a/index.rst
+++ b/index.rst
@@ -28,19 +28,19 @@ Welcome! This is the documentation for Numpy and Scipy.
   <table class="contentstable" align="center"><tr>
     <td width="50%">
       <p class="biglink"><a class="biglink" href="numpy/">Complete Numpy Manual</a><br/>
-        <span><a href="numpy/numpy-html-1.17.0.zip">[HTML+zip]</a></span>
+        <span><a href="numpy/numpy-html.zip">[HTML+zip]</a></span>
       </p>
       <p class="biglink"><a class="biglink" href="numpy/reference/">Numpy Reference Guide</a><br/>
-        <span><a href="numpy/numpy-ref-1.17.0.pdf">[PDF]</a></span>
+        <span><a href="numpy/numpy-ref.pdf">[PDF]</a></span>
       </p>
       <p class="biglink"><a class="biglink" href="numpy/user/">Numpy User Guide</a><br/>
-        <span><a href="https://numpy.org/doc/1.21/numpy-ref.pdf">[PDF]</a></span>
+        <span><a href="numpy/numpy-user.pdf">[PDF]</a></span>
       </p>
       <p class="biglink"><a class="biglink" href="numpy/f2py/">F2Py Guide</a><br/>
       </p>
       <p class="biglink"><a class="biglink" href="scipy/reference/">Scipy Reference Guide</a><br/>
-        <span><a href="scipy/scipy-html-1.7.1.zip">[HTML+zip]</a>,
-          <a href="scipy/scipy-ref-1.7.1.pdf">[PDF]</a></span>
+        <span><a href="scipy/scipy-html.zip">[HTML+zip]</a>,
+          <a href="scipy/scipy-ref.pdf">[PDF]</a></span>
       </p>
     </td></tr>
   </table>
@@ -61,7 +61,11 @@ Welcome! This is the documentation for Numpy and Scipy.
          Numpy (development version) User Guide</a>
       </p>
       <p><a href="numpy-1.17.0/reference/">Numpy 1.17.0 Reference Guide</a>,
-        <span><a href="numpy-1.17.0/numpy-html-1.17.0.zip">[HTML+zip]</a>,
+        <span><a href="numpy-1.17.0/numpy-html-1.17.0
+        
+        
+        
+        ">[HTML+zip]</a>,
           <a href="numpy-1.17.0/numpy-ref-1.17.0.pdf">[PDF]</a></span>
       </p>
       <p><a href="numpy-1.17.0/user/">Numpy 1.17.0 User Guide</a>,


### PR DESCRIPTION
currently:

numpy/numpy-ref-1.17.0.pdf  
is  
https://docs.scipy.org/doc/numpy/numpy-ref-1.17.0.pdf  
-->  
https://numpy.org/doc/stable/numpy-ref-1.17.0.pdf  
which 404s


this is an attempt to fix with absolute URL https://numpy.org/doc/1.21/numpy-ref.pdf

perhaps even better would be https://numpy.org/doc/stable/numpy-ref.pdf